### PR TITLE
查询武器信息时，把武器信息加入排序

### DIFF
--- a/egenshin/player_info/info_card.py
+++ b/egenshin/player_info/info_card.py
@@ -119,13 +119,48 @@ async def draw_info_card(uid, qid, nickname, raw_data, max_chara=None, group_id=
 
     char_data = raw_data.avatars
 
+    detail_info = None
+    detail_info_height = 0
+    if max_chara == None and SHOW_WEAPON_INFO:
+        detail_info = await gen_detail_info(
+            uid, [x.id for x in raw_data.avatars if not x.get('weapon')], qid,
+            group_id)
+        detail_info_height = weapon_bg.height
+        detail_info = {x['id']: x for x in raw_data.avatars + detail_info}
+
+    avatar_cards = []
+    for chara in char_data[:max_chara or len(char_data)]:
+        card = await avatar_card(chara['id'], chara["level"],
+                                 chara["actived_constellation_num"],
+                                 chara["fetter"], detail_info
+                                 and detail_info[chara['id']])
+        avatar_cards.append(card)
+
     for k in raw_data.avatars:
         if k['name'] == '旅行者':
-            k['rarity'] = 3
+            k['rarity'] = 4.5
         if k['name'] == '埃洛伊':
             k['rarity'] = 3
 
-    char_data.sort(key=lambda x: (-x['rarity'], -x['actived_constellation_num'], -x['level']))  # , -x['fetter']
+    # 有武器信息时，加入排序
+    if detail_info:
+        for chara in char_data:	
+            chara["detail_info"] = detail_info[chara["id"]]
+        
+        # 在原来的基础上增加武器排序                
+        char_data.sort(
+            key=lambda x: (	
+            -x["rarity"],	
+            -x["actived_constellation_num"],
+            -x["level"],	
+            -x["fetter"],	
+            -x["detail_info"]["weapon"]["rarity"],	
+            -x["detail_info"]["weapon"]["affix_level"],	
+            -x["detail_info"]["weapon"]["level"]
+        )	
+    )
+    else:
+        char_data.sort(key=lambda x: (-x['rarity'], -x['actived_constellation_num'], -x['level'], -x['fetter'])) 
 
     # 头像
     if QQ_Avatar:
@@ -195,22 +230,7 @@ async def draw_info_card(uid, qid, nickname, raw_data, max_chara=None, group_id=
         card_bg = easy_alpha_composite(card_bg.convert('RGBA'), new_abyss_star_bg, (925, 710))
 
 
-    detail_info = None
-    detail_info_height = 0
-    if max_chara == None and SHOW_WEAPON_INFO:
-        detail_info = await gen_detail_info(
-            uid, [x.id for x in raw_data.avatars if not x.get('weapon')], qid,
-            group_id)
-        detail_info_height = weapon_bg.height
-        detail_info = {x['id']: x for x in raw_data.avatars + detail_info}
 
-    avatar_cards = []
-    for chara in char_data[:max_chara or len(char_data)]:
-        card = await avatar_card(chara['id'], chara["level"],
-                                 chara["actived_constellation_num"],
-                                 chara["fetter"], detail_info
-                                 and detail_info[chara['id']])
-        avatar_cards.append(card)
 
     chara_bg = Image.new('RGB', (1080, math.ceil(len(avatar_cards) / 4) *
                                  (315 + detail_info_height)), '#f0ece3')


### PR DESCRIPTION
偷偷的把旅行者星级排到4星前面

排序还是按照原始排序

- 星级
- 命座
- 等级
- 好感度
- 武器星级
- 武器精炼
- 武器等级