### PR TITLE
fix:yss绑定时错误获取到崩坏3的角色信息的问题

### DIFF
--- a/egenshin/player_info/query.py
+++ b/egenshin/player_info/query.py
@@ -102,6 +102,9 @@ async def get_cookie_info(cookie):
     json_data = await res.json(object_hook=Dict)
     try:
         info = json_data.data.list[0]
+        for info in json_data.data.list:
+            if info.game_id == 2:
+                break
     except Exception:
         info = {}
     cookie_info_cache[account_id] = info


### PR DESCRIPTION
之前的方式只取`getGameRecordCard`结果中的list[0]，这个索引对应的可能是崩坏3的角色信息，导致报错：
![image](https://user-images.githubusercontent.com/17588900/152506422-25739a6a-7039-4205-8654-c837e0dd62a2.png)


另一种方法是直接使用

> https://api-takumi.mihoyo.com/binding/api/getUserGameRolesByCookie?game_biz=hk4e_cn

不过返回的格式不同，会破坏很多结构，我没改